### PR TITLE
Ensure that errors thrown are rejected; improve error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusher/push-notifications-server",
-    "version": "0.10.6",
+    "version": "0.11.0",
     "description": "NodeJS Server SDK for Pusher Push Notifications",
     "main": "push-notifications.js",
     "repository": "https://github.com/pusher/push-notifications-node",

--- a/push-notifications.js
+++ b/push-notifications.js
@@ -6,7 +6,7 @@ const INTEREST_STRING_MAX_LENGTH = 164;
 const INTEREST_ARRAY_MAX_LENGTH = 100;
 
 function PushNotifications(options) {
-    if (typeof options !== 'object') {
+    if (options === null || typeof options !== 'object') {
         throw new Error('PushNotifications options object is required');
     }
     if (!options.hasOwnProperty('instanceId')) {
@@ -36,42 +36,54 @@ function PushNotifications(options) {
 }
 
 PushNotifications.prototype.publish = function(interests, publishRequest) {
-    if (interests === undefined) {
-        throw new Error('interests argument is required');
+    if (interests === undefined || interests === null) {
+        return Promise.reject(new Error('interests argument is required'));
     }
     if (!(interests instanceof Array)) {
-        throw new Error('interests argument is must be an array');
+        return Promise.reject(
+            new Error('interests argument is must be an array')
+        );
     }
     if (interests.length < 1) {
-        throw new Error(
-            'Publish requests must target at least one interest to be delivered.'
+        return Promise.reject(
+            new Error(
+                'Publish requests must target at least one interest to be delivered'
+            )
         );
     }
     if (interests.length > INTEREST_ARRAY_MAX_LENGTH) {
-        throw new Error(
-            `Number of interests (${
-                interests.length
-            }) exceeds maximum of ${INTEREST_ARRAY_MAX_LENGTH}.`
+        return Promise.reject(
+            new Error(
+                `Number of interests (${
+                    interests.length
+                }) exceeds maximum of ${INTEREST_ARRAY_MAX_LENGTH}.`
+            )
         );
     }
-    if (publishRequest === undefined) {
-        throw new Error('publishRequest argument is required');
+    if (publishRequest === undefined || publishRequest === null) {
+        return Promise.reject(new Error('publishRequest argument is required'));
     }
     for (const interest of interests) {
         if (typeof interest !== 'string') {
-            throw new Error(`interest ${interest} is not a string`);
-        }
-        if (interest.length > INTEREST_STRING_MAX_LENGTH) {
-            throw new Error(
-                `interest ${interest} is longer than the maximum of ` +
-                    `${INTEREST_STRING_MAX_LENGTH} characters`
+            return Promise.reject(
+                new Error(`interest ${interest} is not a string`)
             );
         }
-        if (!INTERESTS_REGEX.exec(interest)) {
-            throw new Error(
-                `interest "${interest}" contains a forbidden character. ` +
-                    'Allowed characters are: ASCII upper/lower-case letters, ' +
-                    'numbers or one of _-=@,.;'
+        if (interest.length > INTEREST_STRING_MAX_LENGTH) {
+            return Promise.reject(
+                new Error(
+                    `interest ${interest} is longer than the maximum of ` +
+                        `${INTEREST_STRING_MAX_LENGTH} characters`
+                )
+            );
+        }
+        if (!INTERESTS_REGEX.test(interest)) {
+            return Promise.reject(
+                new Error(
+                    `interest "${interest}" contains a forbidden character. ` +
+                        'Allowed characters are: ASCII upper/lower-case letters, ' +
+                        'numbers or one of _-=@,.;'
+                )
             );
         }
     }

--- a/tests.js
+++ b/tests.js
@@ -17,6 +17,9 @@ describe('PushNotifications Node SDK', () => {
             expect(() => PushNotifications()).to.throw(
                 'PushNotifications options object is required'
             );
+            expect(() => PushNotifications(null)).to.throw(
+                'PushNotifications options object is required'
+            );
         });
 
         it('should fail if no instanceId passed', () => {
@@ -132,27 +135,35 @@ describe('PushNotifications Node SDK', () => {
         });
 
         it('should fail if no interests nor publishRequest are passed', () => {
-            expect(() => pn.publish()).to.throw(
-                'interests argument is required'
-            );
+            return pn.publish().catch(error => {
+                expect(error.message).to.equal(
+                    'interests argument is required'
+                );
+            });
         });
 
         it('should fail if interests parameter passed is not an array', () => {
-            expect(() => pn.publish('donuts')).to.throw(
-                'interests argument is must be an array'
-            );
+            return pn.publish('donuts').catch(error => {
+                expect(error.message).to.equal(
+                    'interests argument is must be an array'
+                );
+            });
         });
 
         it('should fail if no publishRequest is passed', () => {
-            expect(() => pn.publish(['donuts'])).to.throw(
-                'publishRequest argument is required'
-            );
+            return pn.publish(['donuts']).catch(error => {
+                expect(error.message).to.equal(
+                    'publishRequest argument is required'
+                );
+            });
         });
 
         it('should fail if no interests are passed', () => {
-            expect(() => pn.publish([], {})).to.throw(
-                'Publish requests must target at least one interest to be delivered'
-            );
+            return pn.publish([], {}).catch(error => {
+                expect(error.message).to.equal(
+                    'Publish requests must target at least one interest to be delivered'
+                );
+            });
         });
 
         it('should fail if too many interests are passed', () => {
@@ -161,7 +172,9 @@ describe('PushNotifications Node SDK', () => {
             for (let i = 0; i < MAX_INTERESTS + 1; i++) {
                 interests.push(randomValueHex(15));
             }
-            expect(() => pn.publish(interests, {})).to.throw();
+            return pn.publish(interests, {}).catch(error => {
+                expect(error).not.to.be.undefined;
+            });
         });
 
         it('should succeed if there are 100 interests', () => {
@@ -173,25 +186,37 @@ describe('PushNotifications Node SDK', () => {
         });
 
         it('should fail if an interest is not a string', () => {
-            expect(() => pn.publish(['good_interest', false], {})).to.throw(
-                'interest false is not a string'
-            );
+            return pn.publish(['good_interest', false], {}).catch(error => {
+                expect(error.message).to.equal(
+                    'interest false is not a string'
+                );
+            });
         });
 
         it('should fail if an interest is too long', () => {
-            expect(() =>
-                pn.publish(['good_interest', 'a'.repeat(165)], {})
-            ).to.throw('is longer than the maximum of 164 characters');
+            return pn
+                .publish(['good_interest', 'a'.repeat(165)], {})
+                .catch(error => {
+                    expect(error.message).to.match(
+                        /is longer than the maximum of 164 characters/
+                    );
+                });
         });
 
         it('should fail if an interest contains invalid characters', () => {
-            expect(() =>
-                pn.publish(['good-interest', 'bad|interest'], {})
-            ).to.throw('contains a forbidden character');
-
-            expect(() =>
-                pn.publish(['good-interest', 'bad:interest'], {})
-            ).to.throw('contains a forbidden character');
+            return pn
+                .publish(['good-interest', 'bad|interest'], {})
+                .catch(error => {
+                    expect(error.message).to.match(
+                        /contains a forbidden character/
+                    );
+                    return pn.publish(['good-interest', 'bad:interest'], {});
+                })
+                .catch(error => {
+                    expect(error.message).to.match(
+                        /contains a forbidden character/
+                    );
+                });
         });
 
         it('should reject the returned promise on network error', () => {


### PR DESCRIPTION
While looking into an issue where publishing a notification throws an error (invalid interest),
it became clear that the function call threw without rejecting as part of the promise that the
function call otherwise returns. To illustrate what was happening:

```javascript
pushNotifications.publish(interests, options)
  .then(result => {
    // ...
  })
  .catch(error => {
    // We don't get here, the original function call just throws
  });
```

Basically, the way the library works at the moment, you would both have to wrap calls in `try/catch` and `.catch` the returned promise.

I've updated the publish function to reject instead of throwing directly and updated the tests accordingly.