### PR TITLE
fix: add missing return statement

### DIFF
--- a/push-notifications.js
+++ b/push-notifications.js
@@ -124,6 +124,7 @@ function doRequest(payload, options) {
                     reject(
                         new Error('Unknown error - invalid server response')
                     );
+                    return;
                 }
                 if (wasSuccessful) {
                     resolve(responseBody);


### PR DESCRIPTION
On non json response, eg in front of a proxy, or whatever could happen for the response to not be a valid json, it hasn't been properly rejected

This caused responseBody.error to be read which is a property access on undefined