### PR TITLE
Fix incorrect TypeScript signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -293,7 +293,7 @@ declare class PushNotifications {
      * @param userId The given user id for which to generate a Pusher Beams auth token.
      * @returns a Pusher Beams auth token
      */
-    generateToken(userId: string): { token: PushNotifications.Token }
+    generateToken(userId: string): { token: PushNotifications.Token };
 
     /**
      * Publish a notification to device interest(s).

--- a/index.d.ts
+++ b/index.d.ts
@@ -293,7 +293,7 @@ declare class PushNotifications {
      * @param userId The given user id for which to generate a Pusher Beams auth token.
      * @returns a Pusher Beams auth token
      */
-    generateToken(userId: string): PushNotifications.Token;
+    generateToken(userId: string): { token: PushNotifications.Token }
 
     /**
      * Publish a notification to device interest(s).


### PR DESCRIPTION
## Description

TypeScript definition for `generateToken` does not match the result of this function.

## CHANGELOG

* [CHANGED] Change TypeScript definition 
