### PR TITLE
fix hide_notification_if_site_has_focus type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -277,7 +277,7 @@ declare namespace PushNotifications {
          * If set to true, the notification will not be shown if your site has focus.
          * Default: false.
          */
-        hide_notification_if_site_has_focus?: string;
+        hide_notification_if_site_has_focus?: boolean;
     }
 
     interface PublishResponse {


### PR DESCRIPTION
## Description

fixes #49 and https://github.com/pusher/push-notifications-web/issues/108. Changes `hide_notification_if_site_has_focus` from string to boolean. 
 
## CHANGELOG

* [CHANGED] Fix the `hide_notification_if_site_has_focus` TypeScript 
